### PR TITLE
set the permissions on localdata correctly

### DIFF
--- a/roles/cluster_infra/templates/resources.tf.j2
+++ b/roles/cluster_infra/templates/resources.tf.j2
@@ -210,6 +210,7 @@ resource "openstack_compute_instance_v2" "cluster_server" {
       - [ systemctl, daemon-reload ]
       - [ systemctl, restart, remote-fs.target ]
       - [ systemctl, restart, systemd-networkd ]
+      - [ chmod, a+rwx , /localdata ]
   EOF
 
   metadata = {


### PR DESCRIPTION
The c600 flavors now have real ephemeral storage provided.   This is correctly mounted by the cloud-config mount module, but with default permissions.    We use runcmd to set `chmod a+rwx  /localdata` (octal didn't work).   